### PR TITLE
Initial network stack

### DIFF
--- a/DarkSky-Practica-A2.xcodeproj/project.pbxproj
+++ b/DarkSky-Practica-A2.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3AE1326B2083E393004190AD /* ForecastViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE1326A2083E393004190AD /* ForecastViewController.swift */; };
 		3AE1326E2083E702004190AD /* CurrentWeatherForecast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE1326D2083E702004190AD /* CurrentWeatherForecast.swift */; };
 		3AE132702083E718004190AD /* DailyWeatherForecast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE1326F2083E718004190AD /* DailyWeatherForecast.swift */; };
+		3AE1327320840965004190AD /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE1327220840965004190AD /* NetworkManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,6 +41,7 @@
 		3AE1326A2083E393004190AD /* ForecastViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastViewController.swift; sourceTree = "<group>"; };
 		3AE1326D2083E702004190AD /* CurrentWeatherForecast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentWeatherForecast.swift; sourceTree = "<group>"; };
 		3AE1326F2083E718004190AD /* DailyWeatherForecast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyWeatherForecast.swift; sourceTree = "<group>"; };
+		3AE1327220840965004190AD /* NetworkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +83,7 @@
 		3AE132402083DB77004190AD /* DarkSky-Practica-A2 */ = {
 			isa = PBXGroup;
 			children = (
+				3AE132712084095B004190AD /* Managers */,
 				3AE1326C2083E6E8004190AD /* Models */,
 				3AE132692083E36A004190AD /* Views */,
 				3AE132662083DF13004190AD /* Services */,
@@ -164,6 +167,14 @@
 				3AE1326F2083E718004190AD /* DailyWeatherForecast.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		3AE132712084095B004190AD /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				3AE1327220840965004190AD /* NetworkManager.swift */,
+			);
+			path = Managers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -267,6 +278,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3AE1327320840965004190AD /* NetworkManager.swift in Sources */,
 				3AE132682083DF2A004190AD /* WeatherService.swift in Sources */,
 				3AE1326E2083E702004190AD /* CurrentWeatherForecast.swift in Sources */,
 				3AE132422083DB77004190AD /* AppDelegate.swift in Sources */,

--- a/DarkSky-Practica-A2.xcodeproj/project.pbxproj
+++ b/DarkSky-Practica-A2.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		3AE132472083DB77004190AD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3AE132452083DB77004190AD /* Main.storyboard */; };
 		3AE132492083DB77004190AD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3AE132482083DB77004190AD /* Assets.xcassets */; };
 		3AE1324C2083DB77004190AD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3AE1324A2083DB77004190AD /* LaunchScreen.storyboard */; };
+		3AE132682083DF2A004190AD /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE132672083DF2A004190AD /* WeatherService.swift */; };
+		3AE1326B2083E393004190AD /* ForecastViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE1326A2083E393004190AD /* ForecastViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -32,6 +34,8 @@
 		3AE1324D2083DB77004190AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3AE132522083DB77004190AD /* DarkSky-Practica-A2Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "DarkSky-Practica-A2Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3AE132582083DB77004190AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3AE132672083DF2A004190AD /* WeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherService.swift; sourceTree = "<group>"; };
+		3AE1326A2083E393004190AD /* ForecastViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +77,8 @@
 		3AE132402083DB77004190AD /* DarkSky-Practica-A2 */ = {
 			isa = PBXGroup;
 			children = (
+				3AE132692083E36A004190AD /* Views */,
+				3AE132662083DF13004190AD /* Services */,
 				3AE132652083DC0E004190AD /* AppDelegate */,
 				3AE132632083DBB5004190AD /* Storyboards */,
 				3AE132612083DB98004190AD /* Resources */,
@@ -128,6 +134,22 @@
 				3AE132412083DB77004190AD /* AppDelegate.swift */,
 			);
 			path = AppDelegate;
+			sourceTree = "<group>";
+		};
+		3AE132662083DF13004190AD /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				3AE132672083DF2A004190AD /* WeatherService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		3AE132692083E36A004190AD /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				3AE1326A2083E393004190AD /* ForecastViewController.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -231,7 +253,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3AE132682083DF2A004190AD /* WeatherService.swift in Sources */,
 				3AE132422083DB77004190AD /* AppDelegate.swift in Sources */,
+				3AE1326B2083E393004190AD /* ForecastViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DarkSky-Practica-A2.xcodeproj/project.pbxproj
+++ b/DarkSky-Practica-A2.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		3AE1324C2083DB77004190AD /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3AE1324A2083DB77004190AD /* LaunchScreen.storyboard */; };
 		3AE132682083DF2A004190AD /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE132672083DF2A004190AD /* WeatherService.swift */; };
 		3AE1326B2083E393004190AD /* ForecastViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE1326A2083E393004190AD /* ForecastViewController.swift */; };
+		3AE1326E2083E702004190AD /* CurrentWeatherForecast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE1326D2083E702004190AD /* CurrentWeatherForecast.swift */; };
+		3AE132702083E718004190AD /* DailyWeatherForecast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AE1326F2083E718004190AD /* DailyWeatherForecast.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -36,6 +38,8 @@
 		3AE132582083DB77004190AD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3AE132672083DF2A004190AD /* WeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherService.swift; sourceTree = "<group>"; };
 		3AE1326A2083E393004190AD /* ForecastViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForecastViewController.swift; sourceTree = "<group>"; };
+		3AE1326D2083E702004190AD /* CurrentWeatherForecast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentWeatherForecast.swift; sourceTree = "<group>"; };
+		3AE1326F2083E718004190AD /* DailyWeatherForecast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyWeatherForecast.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,6 +81,7 @@
 		3AE132402083DB77004190AD /* DarkSky-Practica-A2 */ = {
 			isa = PBXGroup;
 			children = (
+				3AE1326C2083E6E8004190AD /* Models */,
 				3AE132692083E36A004190AD /* Views */,
 				3AE132662083DF13004190AD /* Services */,
 				3AE132652083DC0E004190AD /* AppDelegate */,
@@ -150,6 +155,15 @@
 				3AE1326A2083E393004190AD /* ForecastViewController.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		3AE1326C2083E6E8004190AD /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				3AE1326D2083E702004190AD /* CurrentWeatherForecast.swift */,
+				3AE1326F2083E718004190AD /* DailyWeatherForecast.swift */,
+			);
+			path = Models;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -254,7 +268,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				3AE132682083DF2A004190AD /* WeatherService.swift in Sources */,
+				3AE1326E2083E702004190AD /* CurrentWeatherForecast.swift in Sources */,
 				3AE132422083DB77004190AD /* AppDelegate.swift in Sources */,
+				3AE132702083E718004190AD /* DailyWeatherForecast.swift in Sources */,
 				3AE1326B2083E393004190AD /* ForecastViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DarkSky-Practica-A2/Managers/NetworkManager.swift
+++ b/DarkSky-Practica-A2/Managers/NetworkManager.swift
@@ -1,0 +1,32 @@
+//
+//  NetworkManager.swift
+//  DarkSky-Practica-A2
+//
+//  Created by George Royce on 4/15/18.
+//  Copyright © 2018 George Royce. All rights reserved.
+//
+
+import Foundation
+
+
+class NetworkManager {
+    
+    class func getDataFor(url: URL, completion: @escaping (Data) -> ()) {
+        
+        let config = URLSessionConfiguration.default
+        let session = URLSession(configuration: config)
+        let request = URLRequest(url: url)
+        
+        session.dataTask(with: request) { (data, response, error) in
+            guard let responseData = data else {
+                print("could not gather data")
+                return
+            }
+            print(response.debugDescription)
+            completion(responseData)
+            
+            }.resume()
+        
+    }
+    
+}

--- a/DarkSky-Practica-A2/Models/CurrentWeatherForecast.swift
+++ b/DarkSky-Practica-A2/Models/CurrentWeatherForecast.swift
@@ -1,0 +1,25 @@
+//
+//  CurrentWeatherForecast.swift
+//  DarkSky-Practica-A2
+//
+//  Created by George Royce on 4/15/18.
+//  Copyright © 2018 George Royce. All rights reserved.
+//
+
+import Foundation
+
+struct CurrentWeatherForecast {
+    
+    let temperature: Float
+    
+    init(_ raw: RawCurrentWeatherForecast) {
+        temperature = raw.temperature
+    }
+    
+}
+
+struct RawCurrentWeatherForecast: Codable {
+    
+    let temperature: Float
+    
+}

--- a/DarkSky-Practica-A2/Models/DailyWeatherForecast.swift
+++ b/DarkSky-Practica-A2/Models/DailyWeatherForecast.swift
@@ -1,0 +1,17 @@
+//
+//  DailyWeatherForecast.swift
+//  DarkSky-Practica-A2
+//
+//  Created by George Royce on 4/15/18.
+//  Copyright © 2018 George Royce. All rights reserved.
+//
+
+import Foundation
+
+struct DailyWeatherForecast {
+    
+}
+
+struct RawDailyWeatherForecast: Codable {
+    
+}

--- a/DarkSky-Practica-A2/Services/WeatherService.swift
+++ b/DarkSky-Practica-A2/Services/WeatherService.swift
@@ -56,24 +56,3 @@ class WeatherSerivce {
     }
 }
 
-class NetworkManager {
-    
-    class func getDataFor(url: URL, completion: @escaping (Data) -> ()) {
-        
-        let config = URLSessionConfiguration.default
-        let session = URLSession(configuration: config)
-        let request = URLRequest(url: url)
-        
-        session.dataTask(with: request) { (data, response, error) in
-            guard let responseData = data else {
-                print("could not gather data")
-                return
-            }
-            print(response.debugDescription)
-            completion(responseData)
-            
-        }.resume()
-        
-    }
-    
-}

--- a/DarkSky-Practica-A2/Services/WeatherService.swift
+++ b/DarkSky-Practica-A2/Services/WeatherService.swift
@@ -1,0 +1,68 @@
+//
+//  WeatherService.swift
+//  DarkSky-Practica-A2
+//
+//  Created by George Royce on 4/15/18.
+//  Copyright © 2018 George Royce. All rights reserved.
+//
+
+import Foundation
+
+class WeatherSerivce {
+    //gather credentials
+//    https://api.darksky.net/forecast/0123456789abcdef9876543210fedcba/42.3601,-71.0589
+    private let latitude = 42.3601
+    private let longitude = -71.0589
+    private let darkSkyScheme = "https"
+    private let darkSkyHost = "api.darksky.net"
+    private let darkSkyKey = ""
+    
+    //compose url
+    private func darkSkyURL() -> URL? {
+        var components = URLComponents()
+        components.scheme = darkSkyScheme
+        components.host = darkSkyHost
+        components.path = darkSkyPath()
+        
+        return components.url
+    }
+    
+    private func darkSkyPath() -> String {
+        return "/forecast/\(darkSkyKey)/\(latitude),\(longitude)"
+    }
+    
+    //pass url in to NetworkManager to fetch data
+    func fetchCurrentWeatherForecast(completion: () -> ()) {
+        guard let url = darkSkyURL() else {
+            print("could not construct url")
+            return
+        }
+        
+        NetworkManager.getDataFor(url: url) { (data) in
+            //take data and parse into models
+            
+        }
+    }
+}
+
+class NetworkManager {
+    
+    class func getDataFor(url: URL, completion: @escaping (Data) -> ()) {
+        
+        let config = URLSessionConfiguration.default
+        let session = URLSession(configuration: config)
+        let request = URLRequest(url: url)
+        
+        session.dataTask(with: request) { (data, response, error) in
+            guard let responseData = data else {
+                print("could not gather data")
+                return
+            }
+            print(response.debugDescription)
+            completion(responseData)
+            
+        }.resume()
+        
+    }
+    
+}

--- a/DarkSky-Practica-A2/Services/WeatherService.swift
+++ b/DarkSky-Practica-A2/Services/WeatherService.swift
@@ -8,6 +8,13 @@
 
 import Foundation
 
+private struct WeatherInfo: Codable {
+    
+    let currently: RawCurrentWeatherForecast
+    let daily: RawDailyWeatherForecast
+    
+}
+
 class WeatherSerivce {
     //gather credentials
 //    https://api.darksky.net/forecast/0123456789abcdef9876543210fedcba/42.3601,-71.0589
@@ -15,9 +22,7 @@ class WeatherSerivce {
     private let longitude = -71.0589
     private let darkSkyScheme = "https"
     private let darkSkyHost = "api.darksky.net"
-    private let darkSkyKey = ""
     
-    //compose url
     private func darkSkyURL() -> URL? {
         var components = URLComponents()
         components.scheme = darkSkyScheme
@@ -31,7 +36,6 @@ class WeatherSerivce {
         return "/forecast/\(darkSkyKey)/\(latitude),\(longitude)"
     }
     
-    //pass url in to NetworkManager to fetch data
     func fetchCurrentWeatherForecast(completion: () -> ()) {
         guard let url = darkSkyURL() else {
             print("could not construct url")
@@ -40,7 +44,14 @@ class WeatherSerivce {
         
         NetworkManager.getDataFor(url: url) { (data) in
             //take data and parse into models
-            
+            do {
+                let weatherInfo = try JSONDecoder().decode(WeatherInfo.self, from: data)
+                let currentForecast = CurrentWeatherForecast(weatherInfo.currently)
+                print("currentForecast: \(currentForecast.temperature)")
+            }
+            catch {
+                print("could not parse data into models")
+            }
         }
     }
 }

--- a/DarkSky-Practica-A2/Services/WeatherService.swift
+++ b/DarkSky-Practica-A2/Services/WeatherService.swift
@@ -16,11 +16,11 @@ private struct WeatherInfo: Codable {
 }
 
 class WeatherSerivce {
-    //gather credentials
-//    https://api.darksky.net/forecast/0123456789abcdef9876543210fedcba/42.3601,-71.0589
+    
     private let latitude = 42.3601
     private let longitude = -71.0589
     private let darkSkyScheme = "https"
+    private let darkSkyKey = ""
     private let darkSkyHost = "api.darksky.net"
     
     private func darkSkyURL() -> URL? {
@@ -43,7 +43,7 @@ class WeatherSerivce {
         }
         
         NetworkManager.getDataFor(url: url) { (data) in
-            //take data and parse into models
+            
             do {
                 let weatherInfo = try JSONDecoder().decode(WeatherInfo.self, from: data)
                 let currentForecast = CurrentWeatherForecast(weatherInfo.currently)

--- a/DarkSky-Practica-A2/Storyboards/Base.lproj/Main.storyboard
+++ b/DarkSky-Practica-A2/Storyboards/Base.lproj/Main.storyboard
@@ -1,11 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gx1-UC-3At">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <scenes/>
+    <scenes>
+        <!--Forecast View Controller-->
+        <scene sceneID="XQR-g0-U3g">
+            <objects>
+                <viewController id="gx1-UC-3At" customClass="ForecastViewController" customModule="DarkSky_Practica_A2" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="t5t-eG-YcU">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="nKK-Rk-Z8K"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6hY-yF-kIv" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="118" y="137"/>
+        </scene>
+    </scenes>
 </document>

--- a/DarkSky-Practica-A2/Views/ForecastViewController.swift
+++ b/DarkSky-Practica-A2/Views/ForecastViewController.swift
@@ -1,0 +1,22 @@
+//
+//  ForecastViewController.swift
+//  DarkSky-Practica-A2
+//
+//  Created by George Royce on 4/15/18.
+//  Copyright © 2018 George Royce. All rights reserved.
+//
+
+import UIKit
+
+class ForecastViewController: UIViewController {
+    
+    let weatherService = WeatherSerivce()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        weatherService.fetchCurrentWeatherForecast {
+            
+        }
+    }
+
+}


### PR DESCRIPTION
DarkSky's response for a basic forecast request returns 4 separate categories: `currently`, `minutely`, `hourly`, and `weekly`. 

Using raw model type that conform to Codable, and using an intermediary struct `WeatherInfo`, we populate a `CurrentWeatherForecast` model from the response. 